### PR TITLE
JS Support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,9 +11,12 @@ var cssnext = require("postcss-cssnext");
 var precss = require("precss");
 var each = require("postcss-each");
 
+var browserify = require('browserify');
+var babelify = require('babelify');
+var source = require('vinyl-source-stream');
+
 // Compiles the SASS files and moves them into the "assets/stylesheets" directory
 gulp.task("styles", function () {
-  // Looks at the style.scss file for what to include and creates a style.css file
 
   var processors = [
     autoprefixer({browsers: ["last 1 version"]}),
@@ -25,12 +28,17 @@ gulp.task("styles", function () {
   return gulp.src("stylesheets/main.scss")
     .pipe(postcss(processors)).on("error", errorHandler)
     .pipe($.concat('main.css'))
-    // AutoPrefix your CSS so it works between browsers
     .pipe(gulp.dest("output/css"))
-    // Outputs the size of the CSS file
     .pipe($.size({title: "styles"}))
-    // Injects the CSS changes to your browser since Jekyll doesn"t rebuild the CSS
     .pipe(browserSync.reload({stream: true}));
+});
+
+gulp.task("scripts", function () {
+  return browserify({entries: './scripts/main.js', debug: true})
+    .transform(babelify, {"presets": ["es2015"]})
+    .bundle()
+    .pipe(source('main.js'))
+    .pipe(gulp.dest('output/js'));
 });
 
 gulp.task("server", function() {
@@ -43,7 +51,7 @@ gulp.task("server", function() {
   });
 });
 
-gulp.task("watch:html", ['html'], function() {
+gulp.task("watch:html", function() {
   gulp.watch([
     "nanoc.yaml",
     "Rules",
@@ -54,13 +62,20 @@ gulp.task("watch:html", ['html'], function() {
   ], ["html"]);
 });
 
-gulp.task("watch:styles", ['styles'], function() {
+gulp.task("watch:styles", function() {
   gulp.watch([
     "stylesheets/**/*"
   ], ["styles"]);
 });
 
-gulp.task("watch", ["watch:html", "watch:styles"]);
+gulp.task("watch:scripts", function() {
+  gulp.watch([
+    "scripts/**/*"
+  ], ["scripts"]);
+});
+
+
+gulp.task("watch", ["watch:html", "watch:styles", "watch:scripts"]);
 
 gulp.task('html', function(cb) {
   exec("bundle exec nanoc compile", {maxBuffer: 1024 * 1000}, function (err, stdout, stderr) {
@@ -75,7 +90,7 @@ gulp.task("serve", ["server", "watch"], function() {
   $.util.log($.util.colors.green('*** When you want to stop the server, type `control - c` ***'));
 });
 
-gulp.task('build', ['html', 'styles']);
+gulp.task('build', ['html', 'styles', 'scripts']);
 
 gulp.task('default', ['watch']);
 

--- a/layouts/splash.html
+++ b/layouts/splash.html
@@ -7,6 +7,7 @@
 
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
+    <script src="/js/main.js"></script>
   </head>
   <body>
     <div id="main">

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -32,7 +32,7 @@ prune:
   # Which files and directories you want to exclude from pruning. If you version
   # your output directory, you should probably exclude VCS directories such as
   # .git, .svn etc.
-  exclude: [ '.git', '.hg', '.svn', 'CVS' ]
+  exclude: [ '.git', '.hg', '.svn', 'CVS', 'js', 'css', 'images' ]
 
 # The data sources where Nanoc loads its data from. This is an array of
 # hashes; each array element represents a single data source. By default,

--- a/package.json
+++ b/package.json
@@ -22,5 +22,11 @@
     "postcss-cssnext": "^2.4.0",
     "postcss-each": "^0.9.1",
     "precss": "^1.4.0"
+  },
+  "devDependencies": {
+    "babel-preset-es2015": "^6.5.0",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/scripts/hello.js
+++ b/scripts/hello.js
@@ -1,0 +1,5 @@
+function hello() {
+  alert("Javascript loaded!");
+}
+
+export default hello;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,5 @@
+import hello from './hello';
+
+window.onload = () => {
+  hello();
+}


### PR DESCRIPTION
- Builds from `scripts/main.js`
- Supports ES6 (eg, `import`)
- Wired into the `splash` layout so the example annoyingly `alert`s