### PR TITLE
Fix a couple of typos

### DIFF
--- a/content/guides/context.md
+++ b/content/guides/context.md
@@ -164,8 +164,8 @@ defmodule MyApp.Router do
   scope "/api" do
     pipe_through :graphql
 
-    forward "/api", Absinthe.Plug,
-      schema: Fractalsense.Web.Schema
+    forward "/", Absinthe.Plug,
+      schema: MyApp.Schema
   end
 end
 ```


### PR DESCRIPTION
* There is no `Fractalsense.Web.Schema` in the whole `context` section, and then it suddenly appeared in the last code example
* having `forward "/api"` inside `scope "/api"` results in `api/api` endpoint