### PR TITLE
updates tutorial to use new enum syntax

### DIFF
--- a/content/tutorial/complex-arguments.md
+++ b/content/tutorial/complex-arguments.md
@@ -12,14 +12,14 @@ We want to support the following mutations.
 ```graphql
 #description "User with email"
 mutation CreateEmailUser {
-  user(contact: {type: "email", value: "foo@bar.com"}, password: "hunter2")
+  user(contact: {type: EMAIL, value: "foo@bar.com"}, password: "hunter2")
 }
 ```
 
 ```graphql
 #description "User with phone number"
 mutation CreatePhoneUser {
-  user(contact: {type: "phone", value: "867-5309"}, password: "hunter2")
+  user(contact: {type: PHONE, value: "867-5309"}, password: "hunter2")
 }
 ```
 
@@ -36,7 +36,8 @@ Let's start with our contact_type Enum.
 ```graphql
 # filename: web/schema/types.ex
 enum :contact_type do
-  values ~w(phone email)a
+  value :phone
+  value :email
 end
 ```
 


### PR DESCRIPTION
The old syntax no longer works. This PR fixes it so it will work.
I'm not sure if line 39-40 should use uppercase or lowercase (as submitted) eg `value :phone` vs `value :PHONE`

Also should the example app be updated as well? I noticed absinthe_plug behind at version 1.0.0 so I wasn't sure if it was ok to update that as well as the syntax change.