### PR TITLE
Context plug updates for usability and compilation

### DIFF
--- a/content/guides/context-and-authentication.md
+++ b/content/guides/context-and-authentication.md
@@ -98,7 +98,11 @@ out to some unspecified authentication mechanism.
 ```elixir
 defmodule MyApp.Web.Context do
   @behaviour Plug
+
   import Plug.Conn
+  import Ecto.Query, only: [where: 2]
+
+  alias MyApp.{Repo, User}
 
   def init(opts), do: opts
 
@@ -107,9 +111,13 @@ defmodule MyApp.Web.Context do
       {:ok, context} ->
         put_private(conn, :absinthe, %{context: context})
       {:error, reason} ->
-        send_resp(conn, 403, reason)
+        conn
+        |> send_resp(403, reason)
+        |> halt()
       _ ->
-        send_resp(conn, 400, reason)
+        conn
+        |> send_resp(400, "Bad Request")
+        |> halt()
     end
   end
 


### PR DESCRIPTION
The example lacked an import, referenced a missing variable, and didn't scope the `User` or `Repo` modules. More importantly, it lacked the call to `halt()` the connection, resulting in a `Plug.Conn.AlreadySentError` if the 403/400 path was ever reached.