### PR TITLE
Changes to reflect addition of Absinthe.Plug.Parser

### DIFF
--- a/content/guides/plug-phoenix.md
+++ b/content/guides/plug-phoenix.md
@@ -30,8 +30,7 @@ you should plug Absinthe.Plug after Plug.Parsers.
 
 ```elixir
 plug Plug.Parsers,
-  parsers: [:urlencoded, :multipart, :json],
-  pass: ["*/*"],
+  parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
   json_decoder: Poison
 
 plug Absinthe.Plug,


### PR DESCRIPTION
With the addition of `Absinthe.Plug.Parser`, the setup for `Plug.Parsers` will slightly change.

From https://github.com/absinthe-graphql/absinthe_plug/pull/35