### PR TITLE
Enhance avoiding n+1 query

### DIFF
--- a/content/guides/ecto-best-practices.md
+++ b/content/guides/ecto-best-practices.md
@@ -70,6 +70,9 @@ Let's first make a function to get a model by ids.
 defmodule MyApp.Schema.Helpers do
   def by_id(model, ids) do
     import Ecto.Query
+
+    ids = ids |> Enum.uniq
+
     model
     |> where([m], m.id in ^ids)
     |> Repo.all


### PR DESCRIPTION
When using this helper, we might repeat matching condition and ask
database for the same `id` multiple times.

This turns
```
SELECT u0."id"
FROM "users" AS u0
WHERE (u0."id" = ANY($1)) [[1, 1, 1, 2, 1, 1, 1, 1, 1, 2, ...]]
```

into:
```
SELECT u0."id"
FROM "users" AS u0
WHERE (u0."id" = ANY($1)) [[1, 2]]
```