### PR TITLE
Add link to the already existing custom scalars in the custom-scalars guide

### DIFF
--- a/content/guides/custom-scalars.md
+++ b/content/guides/custom-scalars.md
@@ -91,3 +91,4 @@ mutation MarkPostAsRead($postID: ID!, $when: Time!) {
 
 * The `scalar` macro is defined in [Absinthe.Schema.Notation](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#scalar/3).
 * Built-in scalar definitions in [Absinthe.Type.BuiltIns.Scalars](https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/type/built_ins/scalars.ex).
+* Already existing custom scalar definitions in [Absinthe.Type.Custom](https://hexdocs.pm/absinthe/Absinthe.Type.Custom.html#content).


### PR DESCRIPTION
It looks like you were trying to keep it concise. If you want to change that, we could also add something like:
* Absinthe already ships with a few custom scalar types. Be sure to check them out in [Absinthe.Type.Custom](https://hexdocs.pm/absinthe/Absinthe.Type.Custom.html#content) before you implement your own naive_datetime scalar. 