### PR TITLE
Updates Timex scalar example to 3.0.0 API

### DIFF
--- a/content/tutorial/scalar-types.md
+++ b/content/tutorial/scalar-types.md
@@ -31,8 +31,8 @@ Let's define our time type:
 # filename: web/schema/types.ex
 
 scalar :time, description: "ISOz time" do
-  parse &Timex.DateFormat.parse(&1.value, "{ISOz}")
-  serialize &Timex.DateFormat.format!(&1, "{ISOz}")
+  parse &Timex.parse(&1.value, "{ISO:Extended:Z}")
+  serialize &Timex.format!(&1, "{ISO:Extended:Z}")
 end
 ```
 


### PR DESCRIPTION
The site shows sample code that no longer works with the current `timex` API. If you use the code as displayed on the site you get a compile error:

```
warning: function Timex.DateFormat.parse/2 is undefined (module Timex.DateFormat is not available)
  lib/foo_web/schema/types.ex:73

warning: function Timex.DateFormat.format!/2 is undefined (module Timex.DateFormat is not available)
  lib/foo_web/schema/types.ex:74
```

The updated sample code should be functionally equivalent for anyone using `> 3.0.0` of `timex`.