### PR TITLE
remove dependency on timex in time scalar example

### DIFF
--- a/content/tutorial/scalar-types.md
+++ b/content/tutorial/scalar-types.md
@@ -30,9 +30,13 @@ Let's define our time type:
 ```elixir
 # filename: web/schema/types.ex
 
-scalar :time, description: "ISOz time" do
-  parse &Timex.DateFormat.parse(&1.value, "{ISOz}")
-  serialize &Timex.DateFormat.format!(&1, "{ISOz}")
+scalar :time do
+  description """
+  The `Time` scalar type represents an ISO 8601 compliant time string.
+  """
+
+  parse &Time.from_iso8601/1
+  serialize &Time.to_iso8601/1
 end
 ```
 


### PR DESCRIPTION
I'm hoping that this helps people who are building GQL APIs to not have to add timex to their project when they don't have to simply because they copy from this guide.